### PR TITLE
Run application from Makefile with poolboy and epgsql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ run:
 	erl -pa ebin ./deps/*/ebin ./deps/*/include \
 	-name pgapp@127.0.0.1 \
 	-config "pgapp.config" \
-	-eval "application:start(pgapp)."
+	-eval "application:ensure_all_started(pgapp)."
 
 dialyzer: build.plt compile
 	dialyzer --plt $< ebin


### PR DESCRIPTION
Hi,
this change is just to ensure that application starts when 'make run' is executed, necessary since the last change of app.src. My fault when I changed it (app.src) the first time.