### PR TITLE
Fix pgapp_worker failure handling

### DIFF
--- a/src/pgapp_worker.erl
+++ b/src/pgapp_worker.erl
@@ -81,15 +81,16 @@ init(Args) ->
     process_flag(trap_exit, true),
     {ok, connect(#state{start_args = Args, delay = ?INITIAL_DELAY})}.
 
+handle_call(_Query, _From, #state{conn = undefined} = State) ->
+    {reply, {error, disconnected}, State};
 handle_call({squery, Sql}, _From,
-            #state{conn=Conn} = State) when Conn /= undefined ->
+            #state{conn=Conn} = State) ->
     {reply, epgsql:squery(Conn, Sql), State};
 handle_call({equery, Sql, Params}, _From,
-            #state{conn = Conn} = State) when Conn /= undefined ->
+            #state{conn = Conn} = State) ->
     {reply, epgsql:equery(Conn, Sql, Params), State};
-
 handle_call({transaction, Fun}, _From,
-            #state{conn = Conn} = State) when Conn /= undefined ->
+            #state{conn = Conn} = State) ->
     put(?STATE_VAR, Conn),
     Result = epgsql:with_transaction(Conn, fun(_) -> Fun() end),
     erase(?STATE_VAR),
@@ -119,7 +120,9 @@ handle_info({'EXIT', From, Reason}, State) ->
       [self(), From, Reason, NewDelay]),
     {noreply, State#state{conn = undefined, delay = NewDelay, timer = Tref}}.
 
-terminate(_Reason, #state{conn=Conn}) ->
+terminate(_Reason, #state{conn = undefined}) ->
+    ok;
+terminate(_Reason, #state{conn = Conn}) ->
     ok = epgsql:close(Conn),
     ok.
 


### PR DESCRIPTION
Avoid pgapp_worker crashing when querying
and Conn is undefined, instead return {error, disconnected}.
Do not try closing the socket when Conn is undefined, to be
able to gracefully terminate.

Is this what we want here? So we can do
```Erlang
case pgapp:squery(psql1, <<"something">>) of
    {something} -> ok;
    {error, disconnected} -> eventually_handle_failure()
end
```