### PR TITLE
Handle timeouts without crashing, using a middle-man process

### DIFF
--- a/src/pgapp.erl
+++ b/src/pgapp.erl
@@ -31,7 +31,7 @@ connect(PoolName, Settings) ->
 
 -spec equery(Sql    :: epgsql:sql_query(),
              Params :: list(epgsql:bind_param()))
-            -> epgsql:reply(epgsql:equery_row()).
+            -> epgsql:reply(epgsql:equery_row()) | {error, Reason :: any()}.
 equery(Sql, Params) ->
     pgapp_worker:equery(Sql, Params).
 
@@ -42,7 +42,7 @@ equery(Sql, Params) ->
             (PoolName :: atom(),
              Sql::epgsql:sql_query(),
              Params   :: list(epgsql:bind_param()))
-            -> epgsql:reply(epgsql:equery_row()).
+            -> epgsql:reply(epgsql:equery_row()) | {error, Reason :: any()}.
 equery(P1, P2, P3) ->
     pgapp_worker:equery(P1, P2, P3).
 
@@ -50,24 +50,24 @@ equery(P1, P2, P3) ->
              Sql::epgsql:sql_query(),
              Params   :: list(epgsql:bind_param()),
              Timeout  :: atom() | integer())
-            -> epgsql:reply(epgsql:equery_row()).
+            -> epgsql:reply(epgsql:equery_row()) | {error, Reason :: any()}.
 equery(PoolName, Sql, Params, Timeout) ->
     pgapp_worker:equery(PoolName, Sql, Params, Timeout).
 
 -spec squery(Sql :: epgsql:sql_query())
             -> epgsql:reply(epgsql:squery_row()) |
-               [epgsql:reply(epgsql:squery_row())].
+               [epgsql:reply(epgsql:squery_row())] | {error, Reason :: any()}.
 squery(Sql) ->
     pgapp_worker:squery(Sql).
 
 -spec squery(Sql::epgsql:sql_query(),
              Timeout :: atom() | integer())
             -> epgsql:reply(epgsql:squery_row()) |
-               [epgsql:reply(epgsql:squery_row())];
+               [epgsql:reply(epgsql:squery_row())] | {error, Reason :: any()};
             (PoolName :: atom(),
              Sql::epgsql:sql_query())
             -> epgsql:reply(epgsql:squery_row()) |
-               [epgsql:reply(epgsql:squery_row())].
+               [epgsql:reply(epgsql:squery_row())] | {error, Reason :: any()}.
 squery(PoolName, Sql) when is_atom(PoolName) ->
     pgapp_worker:squery(PoolName, Sql);
 squery(Sql, Timeout) ->
@@ -77,33 +77,31 @@ squery(Sql, Timeout) ->
              Sql      :: epgsql:sql_query(),
              Timeout  :: atom() | integer())
             -> epgsql:reply(epgsql:squery_row()) |
-               [epgsql:reply(epgsql:squery_row())].
+               [epgsql:reply(epgsql:squery_row())] | {error, Reason :: any()}.
 squery(PoolName, Sql, Timeout) ->
     pgapp_worker:squery(PoolName, Sql, Timeout).
 
 -spec with_transaction(Function :: fun(() -> Reply))
-                      -> Reply | {rollback, any()} when Reply :: any().
+                      -> Reply | {rollback | error, any()} when Reply :: any().
 with_transaction(Fun) when is_function(Fun, 0) ->
     with_transaction(epgsql_pool, Fun).
 
 -spec with_transaction(PoolName :: atom(),
                        Function :: fun(() -> Reply))
-                      -> Reply | {rollback, any()} when Reply :: any();
+                      -> Reply | {rollback | error, any()} when Reply :: any();
                       (Function :: fun(() -> Reply),
                        Timeout  :: timeout())
-                      -> Reply | {rollback, any()} when Reply :: any().
+                      -> Reply | {rollback | error, any()} when Reply :: any().
 with_transaction(PoolName, Fun) when is_function(Fun, 0);
                                      is_atom(PoolName) ->
     pgapp_worker:with_transaction(PoolName, Fun);
 with_transaction(Fun, Timeout) when is_function(Fun, 0) ->
     pgapp_worker:with_transaction(epgsql_pool, Fun, Timeout).
 
-
-
 -spec with_transaction(PoolName :: atom(),
                        Function :: fun(() -> Reply),
                        Timeout  :: atom() | non_neg_integer())
-                      -> Reply | {rollback, any()} when Reply :: any().
+                      -> Reply | {rollback | error, any()} when Reply :: any().
 with_transaction(PoolName, Fun, Timeout) when is_function(Fun, 0) ->
     pgapp_worker:with_transaction(PoolName, Fun, Timeout).
 


### PR DESCRIPTION
Currently timeouts cause the app to crash. Here we handle this timeouts with a middle-man process to avoiding filling the mailbox with useless messages