### PR TITLE
Fix pgapp:equery/3 spec to allow {error, timeout}.

### DIFF
--- a/src/pgapp.erl
+++ b/src/pgapp.erl
@@ -38,7 +38,7 @@ equery(Sql, Params) ->
 -spec equery(Sql     :: epgsql:sql_query(),
              Params  :: list(epgsql:bind_param()),
              Timeout :: atom() | integer())
-            -> epgsql:reply(epgsql:equery_row());
+            -> epgsql:reply(epgsql:equery_row()) | {error, Reason :: any()};
             (PoolName :: atom(),
              Sql::epgsql:sql_query(),
              Params   :: list(epgsql:bind_param()))


### PR DESCRIPTION
One of the alternatives for the `pgapp:equery/3` spec fails to specify that it can return `{error, Reason::any()}` as the other alternative does.